### PR TITLE
fix: move community page metadata to layout

### DIFF
--- a/src/app/community/layout.tsx
+++ b/src/app/community/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Community - MCP Directory",
+  description:
+    "Join the MCP Directory community. Share your experiences, get help, contribute to the ecosystem, and discover the best Model Context Protocol configurations.",
+  keywords:
+    "MCP community, Model Context Protocol community, MCP forum, MCP support, MCP contributions, AI tools community",
+};
+
+export default function CommunityLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -4,13 +4,6 @@ import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
 import { Star, MessageCircle, Users, TrendingUp, Award, ExternalLink, Heart, Share2 } from "lucide-react";
-import type { Metadata } from "next";
-
-export const metadata: Metadata = {
-  title: "Community - MCP Directory",
-  description: "Join the MCP Directory community. Share your experiences, get help, contribute to the ecosystem, and discover the best Model Context Protocol configurations.",
-  keywords: "MCP community, Model Context Protocol community, MCP forum, MCP support, MCP contributions, AI tools community",
-};
 
 const communityStats = [
   { label: "Active Members", value: "12,847", icon: Users },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,19 +5,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Star, Download, Zap, Shield, Users, ArrowRight, CheckCircle, TrendingUp } from "lucide-react";
 import Link from "next/link";
-import type { Metadata } from "next";
-
-export const metadata: Metadata = {
-  title: "MCP Directory - Setup Multiple MCPs in Minutes, Not Hours",
-  description: "The ultimate directory for Model Context Protocol configurations. Discover, bundle, and deploy verified MCPs with one-click installation. Streamline your AI workflow setup across VS Code, Cursor, Windsurf, and more.",
-  keywords: "MCP, Model Context Protocol, AI tools, automation, package manager, one-click install, AI workflow, development tools, productivity, VS Code, Cursor, Windsurf",
-  openGraph: {
-    title: "MCP Directory - Setup Multiple MCPs in Minutes",
-    description: "Discover, bundle, and deploy Model Context Protocol configurations with one-click installation",
-    type: "website",
-    url: "https://mcp-directory.com",
-  },
-};
 
 export default function Page() {
   return (

--- a/src/contexts/PackageContext.tsx
+++ b/src/contexts/PackageContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { createContext, useContext, useState, useEffect } from 'react';
 
 export interface MCP {


### PR DESCRIPTION
## Summary
- move community page metadata into its own layout to avoid client component export
- remove metadata from client pages
- mark PackageContext as a client component

## Testing
- `npm run build` *(fails: c.useState is not a function or its return value is not iterable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cce94378833288431dfcf97c4edd